### PR TITLE
Bundled ffmpeg/mpv

### DIFF
--- a/lib/utils/music_utils.dart
+++ b/lib/utils/music_utils.dart
@@ -5,6 +5,9 @@ import 'package:ctdm/utils/exceptions_utils.dart';
 import 'package:ctdm/utils/log_utils.dart';
 import 'package:path/path.dart' as path;
 
+String ffmpegPath = "ffmpeg";
+String mpvPath = "mpv";
+
 bool isFastBrstm(String path) {
   return path.endsWith('_f.brstm') ||
       path.endsWith('_F.brstm') ||
@@ -14,8 +17,21 @@ bool isFastBrstm(String path) {
 
 bool isFfmpegInstalled() {
   try {
+    if (Platform.isWindows) {
+      String executablesFolder = File(path.join(
+            path.dirname(Platform.resolvedExecutable),
+            "data",
+            "flutter_assets",
+            "assets",
+            "executables"))
+        .path;
+      if (File("$executablesFolder/ffmpeg.exe").existsSync()) {
+        ffmpegPath = "$executablesFolder/ffmpeg.exe";
+      }
+      logString(LogType.INFO, "bundled ffmpeg found [$ffmpegPath]");
+    }
     ProcessResult res =
-        Process.runSync('ffmpeg', ['-version'], runInShell: false);
+        Process.runSync(ffmpegPath, ['-version'], runInShell: false);
     return res.exitCode == 0;
   } on Exception catch (_) {
     logString(LogType.ERROR,
@@ -26,8 +42,21 @@ bool isFfmpegInstalled() {
 
 bool isMpvInstalled() {
   try {
+    if (Platform.isWindows) {
+      String executablesFolder = File(path.join(
+            path.dirname(Platform.resolvedExecutable),
+            "data",
+            "flutter_assets",
+            "assets",
+            "executables"))
+        .path;
+      if (File("$executablesFolder/mpv.exe").existsSync()) {
+        mpvPath = "$executablesFolder/mpv.exe";
+      }
+      logString(LogType.INFO, "bundled mpv found [$mpvPath]");
+    }
     ProcessResult res =
-        Process.runSync('mpv', ['--version'], runInShell: false);
+        Process.runSync(mpvPath, ['--version'], runInShell: false);
     return res.exitCode == 0;
   } on Exception catch (_) {
     logString(LogType.ERROR,
@@ -135,7 +164,7 @@ Future<File> audioToWavAdpcm(
   double dbIncrease = (targetDb - maxVolume);
   //print(dbIncrease);
   await Process.run(
-      'ffmpeg',
+      ffmpegPath,
       [
         '-y',
         '-i',
@@ -152,7 +181,7 @@ Future<File> audioToWavAdpcm(
 
 Future<File> createFastCopy(String tmpFilePath, String tmpFilePathFast) async {
   await Process.run(
-      'ffmpeg',
+      ffmpegPath,
       [
         '-y',
         '-i',
@@ -272,7 +301,7 @@ Future<String> getLoopPoint(File input) async {
           "executables"))
       .path;
   // ProcessResult p = await Process.run(
-  //     'ffmpeg',
+  //     ffmpegPath,
   //     [
   //       '-i',
   //       input.path,
@@ -332,7 +361,7 @@ Future<String> getLoopPoint(File input) async {
 
 Future<double> getMaxVolumePeak(File input) async {
   ProcessResult p = await Process.run(
-      'ffmpeg',
+      ffmpegPath,
       [
         '-i',
         input.path,
@@ -383,7 +412,7 @@ Future<File> _runCommandToNormalize(
       outputFilePath,
     ];
 
-    await Process.run('ffmpeg', ffmpegArgs, runInShell: true);
+    await Process.run(ffmpegPath, ffmpegArgs, runInShell: true);
   } catch (e) {
     logString(
         LogType.ERROR, "ERROR 5503: Cannot parse ffmpeg.\n${e.toString()}");
@@ -394,7 +423,7 @@ Future<File> _runCommandToNormalize(
 
 Future<File> normalize(File inputFile, File output) async {
   ProcessResult p = await Process.run(
-    'ffmpeg',
+    ffmpegPath,
     [
       '-i',
       inputFile.path,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -78,10 +78,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -281,6 +281,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -301,18 +325,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   merge_images:
     dependency: "direct main"
     description:
@@ -325,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   mpv_dart:
     dependency: transitive
     description:
@@ -341,10 +365,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_drawing:
     dependency: transitive
     description:
@@ -514,18 +538,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -546,10 +570,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   tint:
     dependency: transitive
     description:
@@ -638,14 +662,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "13.0.0"
   win32:
     dependency: transitive
     description:
@@ -679,5 +703,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=3.13.0"


### PR DESCRIPTION
Add a check for Windows users to use bundled known to work versions of ffmpeg/mpv executables (to be added manually in a release/to be downloaded and verified when running the first time). It also updates the pubspec.lock file.